### PR TITLE
Add badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 Rubiz
 =======================
+[![Build Status](https://travis-ci.org/rubicon-project/rubiz.svg?branch=master)](https://travis-ci.org/rubicon-project/rubiz)
+[![codecov.io](https://codecov.io/github/rubicon-project/rubiz/coverage.svg?branch=master)](https://codecov.io/github/rubicon-project/rubiz?branch=master)
+[![scaladoc](https://javadoc-badge.appspot.com/com.rubiconproject/rubiz_2.11.svg?label=scaladoc)](https://javadoc-badge.appspot.com/com.rubiconproject/rubiz_2.11)
+
 
 ## Purpose
 


### PR DESCRIPTION
Add the badges - The javadoc one isn't useful right now. It will after we publish.